### PR TITLE
Added missing requirement to jpackage-utils

### DIFF
--- a/tomcat8.spec
+++ b/tomcat8.spec
@@ -30,6 +30,7 @@ Source2:    %{name}.sysconfig
 Source3:    %{name}.logrotate
 Source4:    %{name}.conf
 #Requires:   jdk
+Requires:   jpackage-utils
 BuildRoot:  %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
 %description


### PR DESCRIPTION
The script, tomcat8.init makes use of this library of functions: /usr/share/java-utils/java-functions which in turn is provided by jpackage-utils. Given Tomcat's refusal to start without this library being present, we ought to include it as a prerequisite via the Requires declaration in the .spec file.