### PR TITLE
Added rm -f ${CATALINA_PID} to stop action of init

### DIFF
--- a/tomcat8.init
+++ b/tomcat8.init
@@ -158,6 +158,7 @@ function stop() {
          count="0"
          if [ -f "${CATALINA_PID}" ]; then
             read kpid < ${CATALINA_PID}
+            rm -fr ${CATALINA_PID}
             until [ "$(ps --pid $kpid | grep -c $kpid)" -eq "0" ] || \
                       [ "$count" -gt "$SHUTDOWN_WAIT" ]; do
                     if [ "$SHUTDOWN_VERBOSE" = "true" ]; then


### PR DESCRIPTION
We've run into a few corner issues with this RPM package + the ${CATALINA_PID}file. Sometimes a previous action (tomcat8 stop) may have partially succeeded, but did not cleanup after itself and delete the PID file. So during a stop, added a explicitrm -f {$CATALINA_PID}` to do this when the stop action is called.